### PR TITLE
[ISSUE-5] fix docs; add missing descriptions

### DIFF
--- a/api/v1alpha1/argocdrole_types.go
+++ b/api/v1alpha1/argocdrole_types.go
@@ -31,9 +31,12 @@ type ArgoCDRoleSpec struct {
 type Rule struct {
 	// +kubebuilder:validation:Enum=clusters;projects;applications;applicationsets;repositories;certificates;accounts;gpgkeys;logs;exec;extensions
 	// +kubebuilder:validation:example=clusters
-	Resource string   `json:"resource"`
-	Verbs    []string `json:"verbs"`
-	Objects  []string `json:"objects"`
+	// Target resource type.
+	Resource string `json:"resource"`
+	// Verbs define the operations that are being performed on the resource.
+	Verbs []string `json:"verbs"`
+	// List of resource's objects the permissions are granted for.
+	Objects []string `json:"objects"`
 }
 
 // ArgoCDRoleStatus defines the observed state of Role

--- a/api/v1alpha1/argocdrole_types.go
+++ b/api/v1alpha1/argocdrole_types.go
@@ -41,9 +41,11 @@ type Rule struct {
 
 // ArgoCDRoleStatus defines the observed state of Role
 type ArgoCDRoleStatus struct {
+	// argocdRoleBindingRef defines the reference to the ArgoCDRoleBinding Resource.
 	ArgoCDRoleBindingRef string `json:"argocdRoleBindingRef,omitempty"`
 	// +listType=map
 	// +listMapKey=type
+	// Conditions defines the list of conditions.
 	Conditions []Condition `json:"conditions,omitempty"`
 }
 

--- a/api/v1alpha1/argocdrole_types.go
+++ b/api/v1alpha1/argocdrole_types.go
@@ -27,6 +27,7 @@ type ArgoCDRoleSpec struct {
 	Rules []Rule `json:"rules"`
 }
 
+// Rules define the desired set of permissions.
 type Rule struct {
 	// +kubebuilder:validation:Enum=clusters;projects;applications;applicationsets;repositories;certificates;accounts;gpgkeys;logs;exec;extensions
 	// +kubebuilder:validation:example=clusters

--- a/api/v1alpha1/argocdrolebinding_types.go
+++ b/api/v1alpha1/argocdrolebinding_types.go
@@ -24,10 +24,12 @@ import (
 
 // ArgoCDRoleBindingSpec defines the desired state of ArgoCDRoleBinding
 type ArgoCDRoleBindingSpec struct {
+	// List of subjects being bound to ArgoCDRole (argocdRoleRef).
 	Subjects      []Subject     `json:"subjects"`
 	ArgoCDRoleRef ArgoCDRoleRef `json:"argocdRoleRef"`
 }
 
+// Kind of the subject (sso, local).
 type Subject struct {
 	// +kubebuilder:validation:Enum=sso;local;role
 	Kind string `json:"kind"`
@@ -45,6 +47,7 @@ type ArgoCDRoleRef struct {
 type ArgoCDRoleBindingStatus struct {
 	// +listType=map
 	// +listMapKey=type
+	// Conditions defines the list of conditions.
 	Conditions []Condition `json:"conditions,omitempty"`
 }
 

--- a/api/v1alpha1/argocdrolebinding_types.go
+++ b/api/v1alpha1/argocdrolebinding_types.go
@@ -35,6 +35,7 @@ type Subject struct {
 	Name string `json:"name"`
 }
 
+// argocdRoleRef defines the reference to the role being granted.
 type ArgoCDRoleRef struct {
 	// Name of the ArgoCDRole. Should not start with "role:"
 	Name string `json:"name"`

--- a/config/crd/bases/rbac-operator.argoproj-labs.io_argocdrolebindings.yaml
+++ b/config/crd/bases/rbac-operator.argoproj-labs.io_argocdrolebindings.yaml
@@ -41,6 +41,7 @@ spec:
             properties:
               argocdRoleRef:
                 // TODO: add desc for argocdRoleRef
+                description: argocdRoleRef defines the reference to the role being granted.
                 properties:
                   name:
                     description: Name of the ArgoCDRole. Should not start with "role:"
@@ -50,10 +51,12 @@ spec:
                 type: object
               subjects:
                 // TODO: add desc for subjects
+                description: List of subjects.
                 items:
                   properties:
                     kind:
                       // TODO: add desc for kind
+                      description: Kind of the subjects.
                       enum:
                       - sso
                       - local
@@ -77,6 +80,7 @@ spec:
             properties:
               conditions:
                 // TODO: add desc for conditions
+                description: Conditions defines the list of conditions.
                 items:
                   description: A Condition that may apply to a resource.
                   properties:

--- a/config/crd/bases/rbac-operator.argoproj-labs.io_argocdrolebindings.yaml
+++ b/config/crd/bases/rbac-operator.argoproj-labs.io_argocdrolebindings.yaml
@@ -40,6 +40,7 @@ spec:
             description: ArgoCDRoleBindingSpec defines the desired state of ArgoCDRoleBinding
             properties:
               argocdRoleRef:
+                // TODO: add desc for argocdRoleRef
                 properties:
                   name:
                     description: Name of the ArgoCDRole. Should not start with "role:"
@@ -48,9 +49,11 @@ spec:
                 - name
                 type: object
               subjects:
+                // TODO: add desc for subjects
                 items:
                   properties:
                     kind:
+                      // TODO: add desc for kind
                       enum:
                       - sso
                       - local
@@ -73,6 +76,7 @@ spec:
             description: ArgoCDRoleBindingStatus defines the observed state of ArgoCDRoleBinding
             properties:
               conditions:
+                // TODO: add desc for conditions
                 items:
                   description: A Condition that may apply to a resource.
                   properties:

--- a/config/crd/bases/rbac-operator.argoproj-labs.io_argocdrolebindings.yaml
+++ b/config/crd/bases/rbac-operator.argoproj-labs.io_argocdrolebindings.yaml
@@ -40,7 +40,6 @@ spec:
             description: ArgoCDRoleBindingSpec defines the desired state of ArgoCDRoleBinding
             properties:
               argocdRoleRef:
-                // TODO: add desc for argocdRoleRef
                 description: argocdRoleRef defines the reference to the role being granted.
                 properties:
                   name:
@@ -50,12 +49,10 @@ spec:
                 - name
                 type: object
               subjects:
-                // TODO: add desc for subjects
                 description: List of subjects.
                 items:
                   properties:
                     kind:
-                      // TODO: add desc for kind
                       description: Kind of the subjects.
                       enum:
                       - sso
@@ -79,7 +76,6 @@ spec:
             description: ArgoCDRoleBindingStatus defines the observed state of ArgoCDRoleBinding
             properties:
               conditions:
-                // TODO: add desc for conditions
                 description: Conditions defines the list of conditions.
                 items:
                   description: A Condition that may apply to a resource.

--- a/config/crd/bases/rbac-operator.argoproj-labs.io_argocdrolebindings.yaml
+++ b/config/crd/bases/rbac-operator.argoproj-labs.io_argocdrolebindings.yaml
@@ -40,7 +40,8 @@ spec:
             description: ArgoCDRoleBindingSpec defines the desired state of ArgoCDRoleBinding
             properties:
               argocdRoleRef:
-                description: argocdRoleRef defines the reference to the role being granted.
+                description: argocdRoleRef defines the reference to the role being
+                  granted.
                 properties:
                   name:
                     description: Name of the ArgoCDRole. Should not start with "role:"
@@ -51,9 +52,9 @@ spec:
               subjects:
                 description: List of subjects being bound to ArgoCDRole (argocdRoleRef).
                 items:
+                  description: Kind of the subject (sso, local).
                   properties:
                     kind:
-                      description: Kind of the subject (sso, local).
                       enum:
                       - sso
                       - local

--- a/config/crd/bases/rbac-operator.argoproj-labs.io_argocdrolebindings.yaml
+++ b/config/crd/bases/rbac-operator.argoproj-labs.io_argocdrolebindings.yaml
@@ -49,11 +49,11 @@ spec:
                 - name
                 type: object
               subjects:
-                description: List of subjects.
+                description: List of subjects being bound to ArgoCDRole (argocdRoleRef).
                 items:
                   properties:
                     kind:
-                      description: Kind of the subjects.
+                      description: Kind of the subject (sso, local).
                       enum:
                       - sso
                       - local

--- a/config/crd/bases/rbac-operator.argoproj-labs.io_argocdrolebindings.yaml
+++ b/config/crd/bases/rbac-operator.argoproj-labs.io_argocdrolebindings.yaml
@@ -40,8 +40,8 @@ spec:
             description: ArgoCDRoleBindingSpec defines the desired state of ArgoCDRoleBinding
             properties:
               argocdRoleRef:
-                description: argocdRoleRef defines the reference to the role being
-                  granted.
+                description: |- 
+                  argocdRoleRef defines the reference to the role being granted.
                 properties:
                   name:
                     description: Name of the ArgoCDRole. Should not start with "role:"
@@ -52,9 +52,9 @@ spec:
               subjects:
                 description: List of subjects being bound to ArgoCDRole (argocdRoleRef).
                 items:
-                  description: Kind of the subject (sso, local).
                   properties:
                     kind:
+                      description: Kind of the subject (sso, local).
                       enum:
                       - sso
                       - local

--- a/config/crd/bases/rbac-operator.argoproj-labs.io_argocdroles.yaml
+++ b/config/crd/bases/rbac-operator.argoproj-labs.io_argocdroles.yaml
@@ -40,13 +40,16 @@ spec:
             description: ArgoCDRoleSpec defines the desired state of Role
             properties:
               rules:
+                // TODO: add desc for rules
                 items:
                   properties:
                     objects:
+                      // TODO: add desc for objects
                       items:
                         type: string
                       type: array
                     resource:
+                      // TODO: add desc for resource
                       enum:
                       - clusters
                       - projects
@@ -61,6 +64,7 @@ spec:
                       - extensions
                       type: string
                     verbs:
+                      // TODO: add desc for verbs
                       items:
                         type: string
                       type: array
@@ -77,8 +81,10 @@ spec:
             description: ArgoCDRoleStatus defines the observed state of Role
             properties:
               argocdRoleBindingRef:
+                // TODO: add desc for argocdRoleBindingRef
                 type: string
               conditions:
+                // TODO: add desc for conditions
                 items:
                   description: A Condition that may apply to a resource.
                   properties:

--- a/config/crd/bases/rbac-operator.argoproj-labs.io_argocdroles.yaml
+++ b/config/crd/bases/rbac-operator.argoproj-labs.io_argocdroles.yaml
@@ -40,18 +40,19 @@ spec:
             description: ArgoCDRoleSpec defines the desired state of Role
             properties:
               rules:
-                description: TESTING
                 // TODO: add desc for rules
+                description: Rules define the desired set of permissions.
                 items:
                   properties:
                     objects:
-                      description: TESTING_OBJECTS
                       // TODO: add desc for objects
+                      description: List of target objects.
                       items:
                         type: string
                       type: array
                     resource:
                       // TODO: add desc for resource
+                      description: Target resource type. 
                       enum:
                       - clusters
                       - projects
@@ -67,6 +68,7 @@ spec:
                       type: string
                     verbs:
                       // TODO: add desc for verbs
+                      description: Verbs define the behaviors of ArgoCDRole.
                       items:
                         type: string
                       type: array
@@ -84,9 +86,11 @@ spec:
             properties:
               argocdRoleBindingRef:
                 // TODO: add desc for argocdRoleBindingRef
+                description: argocdRoleBindingRef specifies the binding to an ArgoCDRole.
                 type: string
               conditions:
                 // TODO: add desc for conditions
+                description: Conditions defines the list of conditions.
                 items:
                   description: A Condition that may apply to a resource.
                   properties:

--- a/config/crd/bases/rbac-operator.argoproj-labs.io_argocdroles.yaml
+++ b/config/crd/bases/rbac-operator.argoproj-labs.io_argocdroles.yaml
@@ -40,18 +40,15 @@ spec:
             description: ArgoCDRoleSpec defines the desired state of Role
             properties:
               rules:
-                // TODO: add desc for rules
                 description: Rules define the desired set of permissions.
                 items:
                   properties:
                     objects:
-                      // TODO: add desc for objects
                       description: List of target objects.
                       items:
                         type: string
                       type: array
                     resource:
-                      // TODO: add desc for resource
                       description: Target resource type. 
                       enum:
                       - clusters
@@ -67,7 +64,6 @@ spec:
                       - extensions
                       type: string
                     verbs:
-                      // TODO: add desc for verbs
                       description: Verbs define the behaviors of ArgoCDRole.
                       items:
                         type: string
@@ -85,11 +81,9 @@ spec:
             description: ArgoCDRoleStatus defines the observed state of Role
             properties:
               argocdRoleBindingRef:
-                // TODO: add desc for argocdRoleBindingRef
                 description: argocdRoleBindingRef defines the reference to the role being granted.
                 type: string
               conditions:
-                // TODO: add desc for conditions
                 description: Conditions defines the list of conditions.
                 items:
                   description: A Condition that may apply to a resource.

--- a/config/crd/bases/rbac-operator.argoproj-labs.io_argocdroles.yaml
+++ b/config/crd/bases/rbac-operator.argoproj-labs.io_argocdroles.yaml
@@ -44,7 +44,7 @@ spec:
                 items:
                   properties:
                     objects:
-                      description: List of target objects.
+                      description: List of resource's objects the permissions are granted for.
                       items:
                         type: string
                       type: array
@@ -64,7 +64,7 @@ spec:
                       - extensions
                       type: string
                     verbs:
-                      description: Verbs define the behaviors of ArgoCDRole.
+                      description: Verbs define the operations that are being performed on the resource.
                       items:
                         type: string
                       type: array
@@ -81,7 +81,7 @@ spec:
             description: ArgoCDRoleStatus defines the observed state of Role
             properties:
               argocdRoleBindingRef:
-                description: argocdRoleBindingRef defines the reference to the role being granted.
+                description: argocdRoleBindingRef defines the reference to the ArgoCDRoleBinding Resource.
                 type: string
               conditions:
                 description: Conditions defines the list of conditions.

--- a/config/crd/bases/rbac-operator.argoproj-labs.io_argocdroles.yaml
+++ b/config/crd/bases/rbac-operator.argoproj-labs.io_argocdroles.yaml
@@ -45,6 +45,7 @@ spec:
                 items:
                   properties:
                     objects:
+                      description: TESTING_OBJECTS
                       // TODO: add desc for objects
                       items:
                         type: string

--- a/config/crd/bases/rbac-operator.argoproj-labs.io_argocdroles.yaml
+++ b/config/crd/bases/rbac-operator.argoproj-labs.io_argocdroles.yaml
@@ -40,12 +40,12 @@ spec:
             description: ArgoCDRoleSpec defines the desired state of Role
             properties:
               rules:
+                description: Rules define the desired set of permissions.
                 items:
-                  description: Rules define the desired set of permissions.
                   properties:
                     objects:
-                      description: List of resource's objects the permissions are
-                        granted for.
+                      description: |-
+                        List of resource's objects the permissions are granted for.
                       items:
                         type: string
                       type: array
@@ -65,8 +65,8 @@ spec:
                       - extensions
                       type: string
                     verbs:
-                      description: Verbs define the operations that are being performed
-                        on the resource.
+                      description: |-
+                        Verbs define the operations that are being performed on the resource.
                       items:
                         type: string
                       type: array
@@ -83,8 +83,8 @@ spec:
             description: ArgoCDRoleStatus defines the observed state of Role
             properties:
               argocdRoleBindingRef:
-                description: argocdRoleBindingRef defines the reference to the ArgoCDRoleBinding
-                  Resource.
+                description: |-
+                  argocdRoleBindingRef defines the reference to the ArgoCDRoleBinding Resource.
                 type: string
               conditions:
                 description: Conditions defines the list of conditions.

--- a/config/crd/bases/rbac-operator.argoproj-labs.io_argocdroles.yaml
+++ b/config/crd/bases/rbac-operator.argoproj-labs.io_argocdroles.yaml
@@ -40,6 +40,7 @@ spec:
             description: ArgoCDRoleSpec defines the desired state of Role
             properties:
               rules:
+                description: TESTING
                 // TODO: add desc for rules
                 items:
                   properties:

--- a/config/crd/bases/rbac-operator.argoproj-labs.io_argocdroles.yaml
+++ b/config/crd/bases/rbac-operator.argoproj-labs.io_argocdroles.yaml
@@ -40,16 +40,17 @@ spec:
             description: ArgoCDRoleSpec defines the desired state of Role
             properties:
               rules:
-                description: Rules define the desired set of permissions.
                 items:
+                  description: Rules define the desired set of permissions.
                   properties:
                     objects:
-                      description: List of resource's objects the permissions are granted for.
+                      description: List of resource's objects the permissions are
+                        granted for.
                       items:
                         type: string
                       type: array
                     resource:
-                      description: Target resource type. 
+                      description: Target resource type.
                       enum:
                       - clusters
                       - projects
@@ -64,7 +65,8 @@ spec:
                       - extensions
                       type: string
                     verbs:
-                      description: Verbs define the operations that are being performed on the resource.
+                      description: Verbs define the operations that are being performed
+                        on the resource.
                       items:
                         type: string
                       type: array
@@ -81,7 +83,8 @@ spec:
             description: ArgoCDRoleStatus defines the observed state of Role
             properties:
               argocdRoleBindingRef:
-                description: argocdRoleBindingRef defines the reference to the ArgoCDRoleBinding Resource.
+                description: argocdRoleBindingRef defines the reference to the ArgoCDRoleBinding
+                  Resource.
                 type: string
               conditions:
                 description: Conditions defines the list of conditions.

--- a/config/crd/bases/rbac-operator.argoproj-labs.io_argocdroles.yaml
+++ b/config/crd/bases/rbac-operator.argoproj-labs.io_argocdroles.yaml
@@ -86,7 +86,7 @@ spec:
             properties:
               argocdRoleBindingRef:
                 // TODO: add desc for argocdRoleBindingRef
-                description: argocdRoleBindingRef specifies the binding to an ArgoCDRole.
+                description: argocdRoleBindingRef defines the reference to the role being granted.
                 type: string
               conditions:
                 // TODO: add desc for conditions


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation


**What does this PR do / why we need it**:
1. Add missing field descriptions in https://doc.crds.dev/github.com/argoproj-labs/argocd-rbac-operator@v0.1.0 CRDs

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #5

**How to test changes / Special notes to the reviewer**:
1. The changes can be observed here: https://doc.crds.dev/github.com/jameskim0987/argocd-rbac-operator@v0.6.0-dummy. ( NOTE: after this PR gets merged. The repo release will need to be bumped so that it can be referenced with the latest changes from https://doc.crds.dev ).