### PR TITLE
binary name - Dockerfile and manager manifest vs. release.Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,13 +22,13 @@ COPY version/ version/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o 'rbac-operator' cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/rbac-operator .
 USER 65532:65532
 
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["/rbac-operator"]

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -55,7 +55,7 @@ spec:
         #   type: RuntimeDefault
       containers:
       - command:
-        - /manager
+        - /rbac-operator
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081


### PR DESCRIPTION
the manager manifest uses command `/manager`
this is not present in the released image - the binary is called `rbac-operator`

I'm really not sure if this is the right way to fix it, but the issue is there