### PR TITLE
feat: Add `finalizers` subresource to ArgoCDRole and ArgoCDRoleBindin…

### DIFF
--- a/config/crd/bases/rbac-operator.argoproj-labs.io_argocdrolebindings.yaml
+++ b/config/crd/bases/rbac-operator.argoproj-labs.io_argocdrolebindings.yaml
@@ -128,3 +128,4 @@ spec:
     storage: true
     subresources:
       status: {}
+      finalizers: {}

--- a/config/crd/bases/rbac-operator.argoproj-labs.io_argocdroles.yaml
+++ b/config/crd/bases/rbac-operator.argoproj-labs.io_argocdroles.yaml
@@ -138,3 +138,4 @@ spec:
     storage: true
     subresources:
       status: {}
+      finalizers: {}


### PR DESCRIPTION
### Problem
Controllers were unable to manage finalizers on `ArgoCDRole` and `ArgoCDRoleBinding` resources due to missing subresource support in the CRDs, resulting e.g. in the following error:

```
error when adding finalizer: argocdrolebindings.rb sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
```

### Solution
Updated the `ArgoCDRole` and `ArgoCDRoleBinding` CRDs to include `finalizers` as a subresource, allowing more granular RBAC permissions to manage finalizers without requiring full update access on the main resources.