### PR TITLE
sa argocd-rbac-operator-controller-manager cannot list configmaps at the cluster scope

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,13 +22,13 @@ COPY version/ version/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o rbac-operator cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/rbac-operator .
 USER 65532:65532
 
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["/rbac-operator"]

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: manager
+        kubectl.kubernetes.io/default-container: rbac-operator
       labels:
         control-plane: controller-manager
     spec:
@@ -55,12 +55,12 @@ spec:
         #   type: RuntimeDefault
       containers:
       - command:
-        - /manager
+        - /rbac-operator
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
         image: controller:latest
-        name: manager
+        name: rbac-operator
         securityContext:
           capabilities:
              drop:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -48,13 +48,6 @@ rules:
   - get
   - patch
   - update
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: manager-role
-  namespace: argocd
-rules:
 - apiGroups:
   - ""
   resourceNames:
@@ -62,8 +55,13 @@ rules:
   resources:
   - configmaps
   verbs:
-  - get
-  - list
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
   - watch

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -13,19 +13,3 @@ subjects:
 - kind: ServiceAccount
   name: controller-manager
   namespace: system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  labels:
-    app.kubernetes.io/name: argocd-rbac-operator
-    app.kubernetes.io/managed-by: kustomize
-  name: manager-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: manager-role
-subjects:
-- kind: ServiceAccount
-  name: controller-manager
-  namespace: system


### PR DESCRIPTION
**this MR will allow the operator to get confimaps clusterwide**

:bulb: another way to solve the problem is changing the operator so that it works only with cm in the same namespace (personally I would like this option more)

when trying to run the operator I was getting:

> W1212 18:17:35.941862       1 reflector.go:547] pkg/mod/k8s.io/client-go@v0.30.1/tools/cache/reflector.go:232: failed to list *v1.ConfigMap: configmaps is forbidden: User "system:serviceaccount:argocd:argocd-rbac-operator-controller-manager" cannot list resource "configmaps" in API group "" at the cluster scope
E1212 18:17:35.941892       1 reflector.go:150] pkg/mod/k8s.io/client-go@v0.30.1/tools/cache/reflector.go:232: Failed to watch *v1.ConfigMap: failed to list *v1.ConfigMap: configmaps is forbidden: User "system:serviceaccount:argocd:argocd-rbac-operator-controller-manager" cannot list resource "configmaps" in API group "" at the cluster scope
---

:point_right:  I was able to make it run with the proposed tweaks in the RBAC

---
:information_source: this also solves colliding configmap verbs between _leader-election-role_ and _manager-role_

