### PR TITLE
helmchart: fix deployment and namespace label duplicates

### DIFF
--- a/helm/argocd-rbac-operator/templates/deployment.yaml
+++ b/helm/argocd-rbac-operator/templates/deployment.yaml
@@ -3,7 +3,6 @@ kind: Deployment
 metadata:
   labels: 
   {{- include "argocd-rbac-operator.labels" . | nindent 4 }}
-  {{- include "argocd-rbac-operator.selectorLabels" . | nindent 4 }}
   name: {{ include "argocd-rbac-operator.name" . }}
   namespace: {{ include "argocd-rbac-operator.namespace" . }}
 spec:
@@ -15,7 +14,6 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: rbac-operator
       labels: 
-      {{- include "argocd-rbac-operator.labels" . | nindent 8 }}
       {{- include "argocd-rbac-operator.selectorLabels" . | nindent 8 }}
     spec:
       affinity:

--- a/helm/argocd-rbac-operator/templates/namespace.yaml
+++ b/helm/argocd-rbac-operator/templates/namespace.yaml
@@ -3,5 +3,4 @@ kind: Namespace
 metadata:
   labels:
     {{- include "argocd-rbac-operator.labels" . | nindent 4 }}
-    {{- include "argocd-rbac-operator.selectorLabels" . | nindent 4 }}
   name: {{ include "argocd-rbac-operator.namespace" . }}


### PR DESCRIPTION
fix deployment and namespace labels

see the _helpers.tpl - the selector labels are included in labels

now it produces duplicate labels like this

```
  labels:
    app.kubernetes.io/name: argocd-rbac-operator
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/name: argocd-rbac-operator
    app.kubernetes.io/instance: release-name
```