### PR TITLE
fix(reconciler)[#33]: fix race condition on cm update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,10 +140,12 @@ endif
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/crd | $(KUBECTL) apply -f -
+	$(KUSTOMIZE) build config/cm-role | $(KUBECTL) apply -f -
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
+	$(KUSTOMIZE) build config/cm-role | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/argoprojlabs/argocd-rbac-operator
-  newTag: v0.1.6
+  newTag: v0.1.8


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
Fixes the race condition on CM Update.

Previously if we apply ArgoCDRole and ArgoCDRoleBinding, we would get a race condition/error, stating that the CM has been modified.

With this fix, we check if the error has been thrown due to a conflict, and requeue the reconciliation loop.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #33 

**How to test changes / Special notes to the reviewer**: