### PR TITLE
fix(helm)[#22]: add RBAC permissions to manager role, to allow watch and get on CMs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,10 +140,12 @@ endif
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/crd | $(KUBECTL) apply -f -
+	$(KUSTOMIZE) build config/cm-role | $(KUBECTL) apply -f -
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
+	$(KUSTOMIZE) build config/cm-role | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/argoprojlabs/argocd-rbac-operator
-  newTag: v0.1.6
+  newTag: v0.1.8

--- a/helm/argocd-rbac-operator/templates/manager_role.yaml
+++ b/helm/argocd-rbac-operator/templates/manager_role.yaml
@@ -9,38 +9,21 @@ rules:
   resources:
   - configmaps
   verbs:
+  - get
   - list
+  - watch
 - apiGroups:
   - rbac-operator.argoproj-labs.io
   resources:
   - argocdrolebindings
+  - argocdroles
   verbs:
   - '*'
-  - get
-  - list
 - apiGroups:
   - rbac-operator.argoproj-labs.io
   resources:
   - argocdrolebindings/finalizers
-  verbs:
-  - '*'
-- apiGroups:
-  - rbac-operator.argoproj-labs.io
-  resources:
   - argocdrolebindings/status
-  verbs:
-  - '*'
-- apiGroups:
-  - rbac-operator.argoproj-labs.io
-  resources:
-  - argocdroles
-  verbs:
-  - '*'
-  - get
-  - list
-- apiGroups:
-  - rbac-operator.argoproj-labs.io
-  resources:
   - argocdroles/finalizers
   verbs:
   - '*'
@@ -50,6 +33,3 @@ rules:
   - argocdroles/status
   verbs:
   - '*'
-  - get
-  - patch
-  - update


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

Added permissions to `manager-role` in helm chart, to reflect permissions, when installing with kustomize. Fixes insufficient permissions to watch CMs.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #22 

**How to test changes / Special notes to the reviewer**: