### PR TITLE
Add support for tolerations in helm chart

### DIFF
--- a/helm/argocd-rbac-operator/README.md
+++ b/helm/argocd-rbac-operator/README.md
@@ -282,6 +282,7 @@ After the deletion of the Role or RoleBinding, the Role will also be deleted in 
 | namespace.create | bool | `true` |  |
 | namespace.nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
+| tolerations | object | `[]` |  |
 | readinessProbe.httpGet.path | string | `"/readyz"` |  |
 | readinessProbe.httpGet.port | int | `8081` |  |
 | readinessProbe.initialDelaySeconds | int | `5` |  |

--- a/helm/argocd-rbac-operator/templates/deployment.yaml
+++ b/helm/argocd-rbac-operator/templates/deployment.yaml
@@ -42,6 +42,10 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: 10
       serviceAccountName: {{ include "argocd-rbac-operator.serviceAccountName" . }}
       containers:

--- a/helm/argocd-rbac-operator/values.yaml
+++ b/helm/argocd-rbac-operator/values.yaml
@@ -75,3 +75,5 @@ readinessProbe:
   periodSeconds: 10
 
 nodeSelector: {}
+
+tolerations: []


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What does this PR do / why we need it**:
Allows specifying [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) in the helm chart.

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

**How to test changes / Special notes to the reviewer**:

From `helm/argocd-rbac-operator`:
```
helm template -f values.test.yaml .
```

With e.g. `values.test.yaml`
```
tolerations:
- key: "key1"
  operator: "Equal"
  value: "value1"
  effect: "NoSchedule"
```

Observe in the rendered output that the tolerations are included in the spec.