### PR TITLE
Wire up logging for each Reconciler

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -135,6 +135,7 @@ func main() {
 		Scheme:                       mgr.GetScheme(),
 		ArgoCDRBACConfigMapName:      argoCDRBACConfigMapName,
 		ArgoCDRBACConfigMapNamespace: argoCDRBACConfigMapNamespace,
+		Log:                          ctrl.Log.WithName("controllers").WithName("ArgoCDRole"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Role")
 		os.Exit(1)
@@ -144,12 +145,14 @@ func main() {
 		Scheme:                       mgr.GetScheme(),
 		ArgoCDRBACConfigMapName:      argoCDRBACConfigMapName,
 		ArgoCDRBACConfigMapNamespace: argoCDRBACConfigMapNamespace,
+		Log:                          ctrl.Log.WithName("controllers").WithName("ArgoCDRoleBinding"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ArgoCDRoleBinding")
 		os.Exit(1)
 	}
 	if err := (&controller.ArgoCDProjectRoleReconciler{
 		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName("ArgoCDProjectRole"),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ArgoCDProjectRole")
@@ -158,6 +161,7 @@ func main() {
 	if err := (&controller.ArgoCDProjectRoleBindingReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
+		Log:    ctrl.Log.WithName("controllers").WithName("ArgoCDProjectRoleBinding"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ArgoCDProjectRoleBinding")
 		os.Exit(1)

--- a/internal/controller/argocdrolebinding_controller.go
+++ b/internal/controller/argocdrolebinding_controller.go
@@ -53,17 +53,17 @@ type ArgoCDRoleBindingReconciler struct {
 func (r *ArgoCDRoleBindingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = r.Log.WithValues("argocdrole", req.NamespacedName)
 
-	r.Log.Info("Reconciling ArgoCDRoleBinding %s", req.Name)
+	r.Log.Info("Reconciling ArgoCDRoleBinding", "name", req.Name)
 
 	var rb rbacoperatorv1alpha1.ArgoCDRoleBinding
 	if err := r.Get(ctx, req.NamespacedName, &rb); err != nil {
 		if errors.IsNotFound(err) {
-			r.Log.Info("ArgoCDRoleBinding %s not found.", req.Name)
+			r.Log.Info("ArgoCDRoleBinding not found.", "name", req.Name)
 			return ctrl.Result{}, nil
 		}
 		rb.SetConditions(rbacoperatorv1alpha1.ReconcileError(err))
 		if err := r.Client.Status().Update(ctx, &rb); err != nil {
-			r.Log.Error(err, "Failed to update ArgoCDRoleBinding %s status", req.Name)
+			r.Log.Error(err, "Failed to update ArgoCDRoleBinding status", "name", req.Name)
 		}
 		return ctrl.Result{}, err
 	}
@@ -71,12 +71,12 @@ func (r *ArgoCDRoleBindingReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	if rb.IsBeingDeleted() {
 		if err := r.handleFinalizer(ctx, &rb); err != nil {
 			if errors.IsConflict(err) {
-				r.Log.Info("Conflict while handling finalizer, requeuing ArgoCDRoleBinding %s", req.Name)
+				r.Log.Info("Conflict while handling finalizer, requeuing ArgoCDRoleBinding", "name", req.Name)
 				return ctrl.Result{RequeueAfter: time.Second}, nil
 			}
 			rb.SetConditions(rbacoperatorv1alpha1.Deleting().WithMessage(err.Error()))
 			if err := r.Client.Status().Update(ctx, &rb); err != nil {
-				r.Log.Error(err, "Failed to update ArgoCDRoleBinding %s status", req.Name)
+				r.Log.Error(err, "Failed to update ArgoCDRoleBinding status", "name", req.Name)
 			}
 			return ctrl.Result{}, fmt.Errorf("error when handling finalizer: %v", err)
 		}
@@ -87,7 +87,7 @@ func (r *ArgoCDRoleBindingReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		if err := r.addFinalizer(ctx, &rb); err != nil {
 			rb.SetConditions(rbacoperatorv1alpha1.Deleting().WithMessage(err.Error()))
 			if err := r.Client.Status().Update(ctx, &rb); err != nil {
-				r.Log.Error(err, "Failed to update ArgoCDRoleBinding %s status", req.Name)
+				r.Log.Error(err, "Failed to update ArgoCDRoleBinding status", "name", req.Name)
 			}
 			return ctrl.Result{}, fmt.Errorf("error when adding finalizer: %v", err)
 		}
@@ -100,7 +100,7 @@ func (r *ArgoCDRoleBindingReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	if !IsObjectFound(r.Client, cm.Namespace, cm.Name, cm) {
 		rb.SetConditions(rbacoperatorv1alpha1.Pending(fmt.Errorf("ConfigMap %s not found", cm.Name)))
 		if err := r.Client.Status().Update(ctx, &rb); err != nil {
-			r.Log.Error(err, "Failed to update ArgoCDRoleBinding %s status", req.Name)
+			r.Log.Error(err, "Failed to update ArgoCDRoleBinding status", "name", req.Name)
 		}
 		return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, fmt.Errorf("ConfigMap not found")
 	}
@@ -116,12 +116,12 @@ func (r *ArgoCDRoleBindingReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 		if err := r.Get(ctx, typeNamespacedNameRole, &role); err != nil {
 			if errors.IsNotFound(err) {
-				r.Log.Info("ArgoCDRole %s not found.", roleName)
+				r.Log.Info("ArgoCDRole not found.", "name", roleName)
 				return ctrl.Result{}, nil
 			}
 			rb.SetConditions(rbacoperatorv1alpha1.ReconcileError(err))
 			if err := r.Client.Status().Update(ctx, &rb); err != nil {
-				r.Log.Error(err, "Failed to update ArgoCDRoleBinding %s status", req.Name)
+				r.Log.Error(err, "Failed to update ArgoCDRoleBinding status", "name", req.Name)
 			}
 			return ctrl.Result{}, err
 		}
@@ -130,7 +130,7 @@ func (r *ArgoCDRoleBindingReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		if err := r.reconcileRBACConfigMap(cm, &rb, &role); err != nil {
 			rb.SetConditions(rbacoperatorv1alpha1.ReconcileError(err))
 			if err := r.Client.Status().Update(ctx, &rb); err != nil {
-				r.Log.Error(err, "Failed to update ArgoCDRoleBinding %s status", req.Name)
+				r.Log.Error(err, "Failed to update ArgoCDRoleBinding status", "name", req.Name)
 			}
 			return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, err
 		}
@@ -138,13 +138,13 @@ func (r *ArgoCDRoleBindingReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		if !role.HasArgoCDRoleBindingRef() {
 			role.SetArgoCDRoleBindingRef(rb.Name)
 			if err := r.Client.Status().Update(ctx, &role); err != nil {
-				r.Log.Error(err, "Failed to update ArgoCDRole %s status", role.Name)
+				r.Log.Error(err, "Failed to update ArgoCDRole status", "name", role.Name)
 			}
 		}
 
 		rb.SetConditions(rbacoperatorv1alpha1.ReconcileSuccess().WithObservedGeneration(rb.GetGeneration()))
 		if err := r.Client.Status().Update(ctx, &rb); err != nil {
-			r.Log.Error(err, "Failed to update ArgoCDRoleBinding %s status", req.Name)
+			r.Log.Error(err, "Failed to update ArgoCDRoleBinding status", "name", req.Name)
 		}
 		return ctrl.Result{RequeueAfter: time.Minute * 10}, nil
 
@@ -162,19 +162,19 @@ func (r *ArgoCDRoleBindingReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	r.Log.Info("Reconciling RBAC ConfigMap")
 	if err := r.reconcileRBACConfigMapForBuiltInRole(cm, &rb, role); err != nil {
 		if errors.IsConflict(err) {
-			r.Log.Info("Conflict while reconciling RBAC ConfigMap, requeuing ArgoCDRoleBinding %s", req.Name)
+			r.Log.Info("Conflict while reconciling RBAC ConfigMap, requeuing ArgoCDRoleBinding", "name", req.Name)
 			return ctrl.Result{RequeueAfter: time.Second}, nil
 		}
 		rb.SetConditions(rbacoperatorv1alpha1.ReconcileError(err))
 		if err := r.Client.Status().Update(ctx, &rb); err != nil {
-			r.Log.Error(err, "Failed to update ArgoCDRoleBinding %s status", req.Name)
+			r.Log.Error(err, "Failed to update ArgoCDRoleBinding status", "name", req.Name)
 		}
 		return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, err
 	}
 
 	rb.SetConditions(rbacoperatorv1alpha1.ReconcileSuccess().WithObservedGeneration(rb.GetGeneration()))
 	if err := r.Client.Status().Update(ctx, &rb); err != nil {
-		r.Log.Error(err, "Failed to update ArgoCDRoleBinding %s status", req.Name)
+		r.Log.Error(err, "Failed to update ArgoCDRoleBinding status", "name", req.Name)
 	}
 	return ctrl.Result{RequeueAfter: time.Minute * 10}, nil
 }


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
This PR wires up logging for each individual reconciler and fixes some broken usage of the log function which results in `odd number of arguments passed as key-value pairs for logging`:
```
2025-07-12T10:57:41Z ERROR Observed a panic {"controller": "argocdrole", "controllerGroup": "rbac-operator.argoproj-labs.io", "controllerKind": "ArgoCDRole", "ArgoCDRole": {"name":"argocd-admins","namespace":"engine"}, "namespace": "engine", "name": "argocd-admins", "reconcileID": "043aef1e-7a40-4320-b043-d786033ef197", "panic": "odd number of arguments passed as key-value pairs for logging", "stacktrace": "goroutine 105 [running]:\nk8s.io/apimachinery/pkg/util/runtime.logPanic({0x2c5c0e8, 0xc0007dba10}, {0x216c540, 0xc000505010})\n\t/go/pkg/mod/k8s.io/apimachinery@v0.33.1/pkg/util/runtime/runtime.go:132 +0xbc\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile.func1()\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.1/pkg/internal/controller/controller.go:107 +0x112\npanic({0x216c540?, 0xc000505010?})\n\t/usr/local/go/src/runtime/panic.go:792 +0x132\ngo.uber.org/zap/zapcore.CheckWriteAction.OnWrite(0x26?, 0xb?, {0x0?, 0x0?, 0xc0008054e0?})\n\t/go/pkg/mod/go.uber.org/zap@v1.27.0/zapcore/entry.go:196 +0x54\ngo.uber.org/zap/zapcore.(*CheckedEntry).Write(0xc0006ede10, {0xc0009ca580, 0x1, 0x1})\n\t/go/pkg/mod/go.uber.org/zap@v1.27.0/zapcore/entry.go:262 +0x24a\ngo.uber.org/zap.(*Logger).DPanic(0x26c0e26?, {0x273fcc4?, 0x216c540?}, {0xc0009ca580, 0x1, 0x1})\n\t/go/pkg/mod/go.uber.org/zap@v1.27.0/logger.go:275 +0x4b\ngithub.com/go-logr/zapr.(*zapLogger).handleFields(0xc00049a6f0, 0x0, {0xc000504fc0, 0x1, 0x252d3a0?}, {0x0, 0x0, 0x5?})\n\t/go/pkg/mod/github.com/go-logr/zapr@v1.3.0/zapr.go:147 +0xd45\ngithub.com/go-logr/zapr.(*zapLogger).Info(0xc00049a6f0, 0x0, {0x26dd3e6?, 0x1?}, {0xc000504fc0, 0x1, 0x1})\n\t/go/pkg/mod/github.com/go-logr/zapr@v1.3.0/zapr.go:201 +0x89\ngithub.com/go-logr/logr.Logger.Info({{0x2c627b0?, 0xc00049a6f0?}, 0x2?}, {0x26dd3e6, 0x19}, {0xc000504fc0, 0x1, 0x1})\n\t/go/pkg/mod/github.com/go-logr/logr@v1.4.3/logr.go:280 +0xf3\ngithub.com/argoproj-labs/argocd-rbac-operator/internal/controller.(*ArgoCDRoleReconciler).Reconcile(0xc00001ebe0, {0x2c5c0e8, 0xc0007dba10}, {{{0xc0003aaec6, 0x6}, {0xc0003aaed0, 0xd}}})\n\t/workspace/internal/controller/argocdrole_controller.go:58 +0x16f\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile(0xc0007db980?, {0x2c5c0e8?, 0xc0007dba10?}, {{{0xc0003aaec6?, 0x0?}, {0xc0003aaed0?, 0x0?}}})\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.1/pkg/internal/controller/controller.go:118 +0xbf\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler(0x2c72ea0, {0x2c5c120, 0xc00001eb40}, {{{0xc0003aaec6, 0x6}, {0xc0003aaed0, 0xd}}})\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.1/pkg/internal/controller/controller.go:328 +0x3a5\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem(0x2c72ea0, {0x2c5c120, 0xc00001eb40})\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.1/pkg/internal/controller/controller.go:288 +0x20d\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2()\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.1/pkg/internal/controller/controller.go:249 +0x85\ncreated by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2 in goroutine 84\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.1/pkg/internal/controller/controller.go:245 +0x6b5\n"}
```

**How to test changes / Special notes to the reviewer**:
Run the image with `--zap-log-level=debug` and observe the output.