### PR TITLE
fix(helm): correct kubectl.kubernetes.io/default-container annotation

### DIFF
--- a/helm/argocd-rbac-operator/templates/deployment.yaml
+++ b/helm/argocd-rbac-operator/templates/deployment.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: rbac-operator
+        kubectl.kubernetes.io/default-container: {{ .Chart.Name }}
       labels:
       {{- include "argocd-rbac-operator.labels" . | nindent 8 }}
     spec:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:

**Problem:**
The `kubectl.kubernetes.io/default-container` Pod Annotation in the helm chart has an incorrect value. The `rbac-operator` value doesn't match any container name.

Among other possible issues this could cause with `kubectl`, the name mismatch causes ArgoCD to not display any logs. Error reported by ArgoCD: `container rbac-operator is not valid for pod argocd-rbac-operator-9c9495f66-pgbkf`

**Fix:**
Set `kubectl.kubernetes.io/default-container` to `{{ .Chart.Name }}` which matches the container name: https://github.com/argoproj-labs/argocd-rbac-operator/blob/411ff1a8b6ff5545a0ae666ff1dad2f1457c336b/helm/argocd-rbac-operator/templates/deployment.yaml#L65

Alternatively, since there's only one container in this Pod, we could remove the annotation all together

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

N/A - I didn't file an issue

**How to test changes / Special notes to the reviewer**:

