### PR TITLE
refactor: propagate reconcile context through helper methods

### DIFF
--- a/internal/controller/argocdrole_controller.go
+++ b/internal/controller/argocdrole_controller.go
@@ -100,7 +100,7 @@ func (r *ArgoCDRoleReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	cm := newConfigMap(r.ArgoCDRBACConfigMapName, r.ArgoCDRBACConfigMapNamespace)
 
 	r.Log.Info("Checking if ConfigMap exists")
-	if !IsObjectFound(r.Client, cm.Namespace, cm.Name, cm) {
+	if !IsObjectFound(ctx, r.Client, cm.Namespace, cm.Name, cm) {
 		role.SetConditions(rbacoperatorv1alpha1.Pending(fmt.Errorf("ConfigMap %s not found", cm.Name)))
 		if err := r.Client.Status().Update(ctx, &role); err != nil {
 			r.Log.Error(err, "Failed to update ArgoCDRole status", "name", req.Name)
@@ -133,7 +133,7 @@ func (r *ArgoCDRoleReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			if err := r.Get(ctx, client.ObjectKeyFromObject(cm), cm); err != nil {
 				return err
 			}
-			return r.reconcileRBACConfigMapWithRoleBinding(cm, &role, &rb)
+			return r.reconcileRBACConfigMapWithRoleBinding(ctx, cm, &role, &rb)
 		})
 
 		if err != nil {
@@ -159,7 +159,7 @@ func (r *ArgoCDRoleReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return err
 		}
 
-		return r.reconcileRBACConfigMap(cm, &role)
+		return r.reconcileRBACConfigMap(ctx, cm, &role)
 	})
 
 	if err != nil {

--- a/internal/controller/argocdrolebinding_controller.go
+++ b/internal/controller/argocdrolebinding_controller.go
@@ -98,7 +98,7 @@ func (r *ArgoCDRoleBindingReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	cm := newConfigMap(r.ArgoCDRBACConfigMapName, r.ArgoCDRBACConfigMapNamespace)
 
 	r.Log.Info("Checking if ConfigMap exists")
-	if !IsObjectFound(r.Client, cm.Namespace, cm.Name, cm) {
+	if !IsObjectFound(ctx, r.Client, cm.Namespace, cm.Name, cm) {
 		rb.SetConditions(rbacoperatorv1alpha1.Pending(fmt.Errorf("ConfigMap %s not found", cm.Name)))
 		if err := r.Client.Status().Update(ctx, &rb); err != nil {
 			r.Log.Error(err, "Failed to update ArgoCDRoleBinding status", "name", req.Name)
@@ -133,7 +133,7 @@ func (r *ArgoCDRoleBindingReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			if err := r.Get(ctx, client.ObjectKeyFromObject(cm), cm); err != nil {
 				return err
 			}
-			return r.reconcileRBACConfigMap(cm, &rb, &role)
+			return r.reconcileRBACConfigMap(ctx, cm, &rb, &role)
 		})
 
 		if err != nil {
@@ -174,7 +174,7 @@ func (r *ArgoCDRoleBindingReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		if err := r.Get(ctx, client.ObjectKeyFromObject(cm), cm); err != nil {
 			return err
 		}
-		return r.reconcileRBACConfigMapForBuiltInRole(cm, &rb, role)
+		return r.reconcileRBACConfigMapForBuiltInRole(ctx, cm, &rb, role)
 	})
 
 	if err != nil {

--- a/internal/controller/configmap.go
+++ b/internal/controller/configmap.go
@@ -88,7 +88,7 @@ func newConfigMap(name, namespace string) *corev1.ConfigMap {
 }
 
 // reconcileRBACConfigMap will ensure that the ArgoCD RBAC ConfigMap is up-to-date.
-func (r *ArgoCDRoleReconciler) reconcileRBACConfigMap(cm *corev1.ConfigMap, role *rbacoperatorv1alpha1.ArgoCDRole) error {
+func (r *ArgoCDRoleReconciler) reconcileRBACConfigMap(ctx context.Context, cm *corev1.ConfigMap, role *rbacoperatorv1alpha1.ArgoCDRole) error {
 	changed := false
 	overlayKey := fmt.Sprintf("policy.%s.%s.csv", role.Namespace, role.Name)
 	roleName := fmt.Sprintf("role:%s", role.Name)
@@ -109,13 +109,13 @@ func (r *ArgoCDRoleReconciler) reconcileRBACConfigMap(cm *corev1.ConfigMap, role
 	}
 
 	if changed {
-		return r.Update(context.TODO(), cm)
+		return r.Update(ctx, cm)
 	}
 	return nil
 }
 
 // reconcileRBACConfigMapWithRoleBinding will ensure that the ArgoCD RBAC ConfigMap is up-to-date.
-func (r *ArgoCDRoleReconciler) reconcileRBACConfigMapWithRoleBinding(cm *corev1.ConfigMap, role *rbacoperatorv1alpha1.ArgoCDRole, rb *rbacoperatorv1alpha1.ArgoCDRoleBinding) error {
+func (r *ArgoCDRoleReconciler) reconcileRBACConfigMapWithRoleBinding(ctx context.Context, cm *corev1.ConfigMap, role *rbacoperatorv1alpha1.ArgoCDRole, rb *rbacoperatorv1alpha1.ArgoCDRoleBinding) error {
 	changed := false
 	overlayKey := fmt.Sprintf("policy.%s.%s.csv", role.Namespace, role.Name)
 
@@ -135,13 +135,13 @@ func (r *ArgoCDRoleReconciler) reconcileRBACConfigMapWithRoleBinding(cm *corev1.
 	}
 
 	if changed {
-		return r.Update(context.TODO(), cm)
+		return r.Update(ctx, cm)
 	}
 	return nil
 }
 
 // reconcileRBACConfigMap will ensure that the ArgoCD RBAC ConfigMap is up-to-date.
-func (r *ArgoCDRoleBindingReconciler) reconcileRBACConfigMap(cm *corev1.ConfigMap, rb *rbacoperatorv1alpha1.ArgoCDRoleBinding, role *rbacoperatorv1alpha1.ArgoCDRole) error {
+func (r *ArgoCDRoleBindingReconciler) reconcileRBACConfigMap(ctx context.Context, cm *corev1.ConfigMap, rb *rbacoperatorv1alpha1.ArgoCDRoleBinding, role *rbacoperatorv1alpha1.ArgoCDRole) error {
 	changed := false
 	overlayKey := fmt.Sprintf("policy.%s.%s.csv", role.Namespace, role.Name)
 
@@ -161,13 +161,13 @@ func (r *ArgoCDRoleBindingReconciler) reconcileRBACConfigMap(cm *corev1.ConfigMa
 	}
 
 	if changed {
-		return r.Update(context.TODO(), cm)
+		return r.Update(ctx, cm)
 	}
 	return nil
 }
 
 // reconcileRBACConfigMap will ensure that the ArgoCD RBAC ConfigMap is up-to-date.
-func (r *ArgoCDRoleBindingReconciler) reconcileRBACConfigMapForBuiltInRole(cm *corev1.ConfigMap, rb *rbacoperatorv1alpha1.ArgoCDRoleBinding, role *rbacoperatorv1alpha1.ArgoCDRole) error {
+func (r *ArgoCDRoleBindingReconciler) reconcileRBACConfigMapForBuiltInRole(ctx context.Context, cm *corev1.ConfigMap, rb *rbacoperatorv1alpha1.ArgoCDRoleBinding, role *rbacoperatorv1alpha1.ArgoCDRole) error {
 	changed := false
 	overlayKey := fmt.Sprintf("policy.%s.%s.csv", role.Namespace, role.Name)
 
@@ -187,21 +187,21 @@ func (r *ArgoCDRoleBindingReconciler) reconcileRBACConfigMapForBuiltInRole(cm *c
 	}
 
 	if changed {
-		return r.Update(context.TODO(), cm)
+		return r.Update(ctx, cm)
 	}
 	return nil
 }
 
 // IsObjectFound will perform a basic check that the given object exists via the Kubernetes API.
 // If an error occurs as part of the check, the function will return false.
-func IsObjectFound(client client.Client, namespace string, name string, obj client.Object) bool {
-	return !apierrors.IsNotFound(FetchObject(client, namespace, name, obj))
+func IsObjectFound(ctx context.Context, client client.Client, namespace string, name string, obj client.Object) bool {
+	return !apierrors.IsNotFound(FetchObject(ctx, client, namespace, name, obj))
 }
 
 // FetchObject will retrieve the object with the given namespace and name using the Kubernetes API.
 // The result will be stored in the given object.
-func FetchObject(client client.Client, namespace string, name string, obj client.Object) error {
-	return client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: name}, obj)
+func FetchObject(ctx context.Context, client client.Client, namespace string, name string, obj client.Object) error {
+	return client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, obj)
 }
 
 // createBuiltInAdminRole will return a new built-in ArgoCDRole with admin permissions.


### PR DESCRIPTION
## summary

thread the reconcile `ctx` from the `Reconcile()` entrypoint through all the helpers, and stop using `context.TODO()` in the actual reconcile path. everything should use the request-scoped context now

## problem

We had a bunch of prod helper methods calling `context.TODO()` instead of the ctx controller-runtime hands us. that means cancellations/timeouts dont propagate, so k8s api calls can keep running after reconcile gets cancelled, and shutdown gets kinda weird/unpredictable

## changes

- added a `ctx context.Context` param to helper method signatures
  - `reconcileRBACConfigMap`, `reconcileRBACConfigMapWithRoleBinding`, `reconcileRBACConfigMapForBuiltInRole` (configmap.go)
  - `IsObjectFound`, `FetchObject` (configmap.go)
  - `patchAppProject`, `removeRoleFromAppProject` (appproject.go)
  - `delete` methods + `deleteProjectRoles` (argocdrbac_operator_finalizer.go)
- updated all controller call sites to pass the reconcile ctx through
- no `context.TODO()` left in non-test reconcile/update code paths

## scope

this is just context plumbing. no behavior changes, no timing/conditions/business logic changes

resolves #70