### PR TITLE
Fix/missing return projectrolebinding

### DIFF
--- a/internal/controller/argocdprojectrolebinding_controller.go
+++ b/internal/controller/argocdprojectrolebinding_controller.go
@@ -63,6 +63,7 @@ func (r *ArgoCDProjectRoleBindingReconciler) Reconcile(ctx context.Context, req 
 			r.Log.Error(err, "Failed to update ArgoCDProjectRoleBinding status", "name", req.Name)
 			return ctrl.Result{}, err
 		}
+		return ctrl.Result{}, err
 	}
 
 	if projectRoleBinding.IsBeingDeleted() {

--- a/internal/controller/argocdprojectrolebinding_controller_test.go
+++ b/internal/controller/argocdprojectrolebinding_controller_test.go
@@ -31,6 +31,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	rbacoperatorv1alpha1 "github.com/argoproj-labs/argocd-rbac-operator/api/v1alpha1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+    "sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 var _ reconcile.Reconciler = &ArgoCDProjectRoleBindingReconciler{}
@@ -239,4 +242,33 @@ func TestArgoCDProjectRoleBindingReconciler_BoundAppProjectNotInSpec(t *testing.
 	assert.NoError(t, err)
 	wantAppProject := makeTestAppProject(setAppProjectName("another-app-project"))
 	assert.Equal(t, wantAppProject.Spec.Roles, appProject.Spec.Roles)
+}
+
+func TestArgoCDProjectRoleBindingReconciler_GetTransientError(t *testing.T) {
+    logf.SetLogger(ZapLogger(true))
+
+    scheme := makeTestReconcilerScheme(rbacoperatorv1alpha1.AddToScheme)
+    
+    fakeClient := fake.NewClientBuilder().
+        WithScheme(scheme).
+        WithInterceptorFuncs(interceptor.Funcs{
+            Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+                return fmt.Errorf("simulated transient API error")
+            },
+        }).
+        Build()
+    
+    reconciler := makeTestArgoCDProjectRoleBindingReconciler(fakeClient, scheme)
+
+    req := reconcile.Request{
+        NamespacedName: types.NamespacedName{
+            Name:      testProjectRoleBindingName,
+            Namespace: testNamespace,
+        },
+    }
+
+    res, err := reconciler.Reconcile(context.TODO(), req)
+
+    assert.Error(t, err)
+    assert.Equal(t, reconcile.Result{}, res)
 }

--- a/internal/controller/argocdprojectrolebinding_controller_test.go
+++ b/internal/controller/argocdprojectrolebinding_controller_test.go
@@ -267,8 +267,8 @@ func TestArgoCDProjectRoleBindingReconciler_GetTransientError(t *testing.T) {
         },
     }
 
-    result, err := reconciler.Reconcile(context.TODO(), req)
+    res, err := reconciler.Reconcile(context.TODO(), req)
 
     assert.Error(t, err)
-    assert.Equal(t, reconcile.Result{}, result)
+    assert.Equal(t, reconcile.Result{}, res)
 }

--- a/internal/controller/argocdprojectrolebinding_controller_test.go
+++ b/internal/controller/argocdprojectrolebinding_controller_test.go
@@ -267,8 +267,8 @@ func TestArgoCDProjectRoleBindingReconciler_GetTransientError(t *testing.T) {
         },
     }
 
-    res, err := reconciler.Reconcile(context.TODO(), req)
+    result, err := reconciler.Reconcile(context.TODO(), req)
 
     assert.Error(t, err)
-    assert.Equal(t, reconcile.Result{}, res)
+    assert.Equal(t, reconcile.Result{}, result)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug



**What does this PR do / why we need it**:
The ArgoCDProjectRoleBindingReconciler was missing a return statement after 
handling a transient Get error. This caused reconciliation to continue with 
a zero-value object, potentially leading to unexpected behavior.

This PR adds the missing return statement and a test that verifies the 
reconciler exits correctly after a transient API error on the initial Get.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #66 

**How to test changes / Special notes to the reviewer**:
A new test TestArgoCDProjectRoleBindingReconciler_GetTransientError has been 
added that simulates a transient API error on the initial Get call and verifies 
that the reconciler returns an error without continuing reconciliation.

Run: go test ./internal/controller/...